### PR TITLE
Not manage keys creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,5 @@ gem 'puppet-lint-variable_contains_upcase'
 # rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   gem 'rspec', '~> 2.0'
+  gem 'rake', '~> 10.0'
 end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # puppet-module-eyaml
-===
 
 [![Build Status](https://travis-ci.org/ghoneycutt/puppet-module-eyaml.png?branch=master)](https://travis-ci.org/ghoneycutt/puppet-module-eyaml)
 
@@ -12,9 +11,192 @@ configurable through parameters.
 ===
 
 # Compatibility
----------------
+
 This module is built for use with Puppet v3 with Ruby versions 1.8.7, 1.9.3,
 2.0.0 and 2.1.0. It is supported on the following platforms.
 
 * EL 6
 * EL 7
+
+===
+
+# Parameters
+
+package_name
+--------------
+Hiera-eyaml requires the hiera-eyaml gem to be installed.
+
+-  *Type*: string
+-  *Default*: hiera-eyaml
+
+package_provider
+--------------
+Package provider to install eyaml.
+
+-  *Type*: string
+-  *Default*: gem
+
+package_ensure
+--------------
+We can enforce an specific version of the gem.
+
+-  *Type*: string
+-  *Default*: present
+
+keys_dir
+--------------
+Directory were we will install our public and private keys.
+
+-  *Type*: string
+-  *Default*: "/etc/puppet/keys"
+
+keys_dir_ensure
+--------------
+Ensures $keys_dir is a directory.
+
+-  *Type*: string
+-  *Default*: directory
+
+keys_dir_owner
+--------------
+Ensures that $keys_dir owner is correct.
+
+-  *Type*: string
+-  *Default*: root
+
+keys_dir_group
+--------------
+Ensures that $keys_dir group is correct.
+
+-  *Type*: string
+-  *Default*: root
+
+keys_dir_mode
+--------------
+Ensures the $keys_dir mode is -r-x------.
+
+-  *Type*: integer
+-  *Default*: 0500
+
+public_key_path
+--------------
+Absolute path to the public key.
+
+-  *Type*: string
+-  *Default*: /etc/puppet/keys/public_key.pkcs7.pem
+
+private_key_path
+--------------
+Absolute path to the private key.
+
+-  *Type*: string
+-  *Default*: /etc/puppet/keys/private_key.pkcs7.pem
+
+public_key_mode
+--------------
+Ensures public key permission are -rw-r--r--.
+
+-  *Type*: integer
+-  *Default*: 0644
+
+private_key_mode
+--------------
+Ensures private key permission are -r--------.
+
+-  *Type*: integer
+-  *Default*: 0400
+
+config_dir
+--------------
+Directory were we want to store eyaml configuration.
+
+-  *Type*: string
+-  *Default*: /etc/yaml
+
+config_dir_ensure
+--------------
+
+Ensures $config_dir is a directory.
+
+-  *Type*: string
+-  *Default*: directory
+
+config_dir_owner
+--------------
+Ensures $config_dir owner is the expected.
+
+-  *Type*: string
+-  *Default*: root
+
+config_dir_group
+--------------
+Ensures $config_dir group is the expected.
+
+-  *Type*: string
+-  *Default*: root
+
+config_dir_mode
+--------------
+Ensures $config_dir mode is -rwxr-xr-x.
+
+-  *Type*: integer
+-  *Default*: 0755
+
+config_ensure
+--------------
+Ensures config file is a file.
+
+-  *Type*: string
+-  *Default*: file
+
+config_path
+--------------
+hiera-eyaml config file path.
+
+-  *Type*: string
+-  *Default*: /etc/eyaml/config.yaml
+
+config_owner
+--------------
+Config file owner.
+
+-  *Type*: string
+-  *Default*: root
+
+config_group
+--------------
+Config file group.
+
+-  *Type*: string
+-  *Default*: root
+
+config_mode
+--------------
+Config file mode.
+
+-  *Type*: integer
+-  *Default*: 0644
+
+config_options
+--------------
+eyaml custom configurations like (extension, datadir)
+
+-  *Type*: hash
+-  *Default*: { 'pkcs7_public_key'  => '/etc/puppet/keys/public_key.pkcs7.pem',
+               'pkcs7_private_key' => '/etc/puppet/keys/private_key.pkcs7.pem',
+             },
+
+manage_eyaml_config
+--------------
+Manage eyaml config file.
+
+-  *Type*: bool
+-  *Default*: true
+
+manage_keys
+--------------
+Manage eyaml keys creation
+
+-  *Type*: bool
+-  *Default*: undef
+

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,82 @@
 require 'spec_helper'
 describe 'eyaml' do
 
-  context 'with defaults for all parameters' do
-    it { should contain_class('eyaml') }
+describe 'eyaml', :type => :class do
+    context 'with defaults for all parameters' do
+      it { should contain_class('eyaml') }
+    end
+
+    context "install package" do
+      let (:params) {{ :package_ensure => 'present', :package_name => 'hiera-eyaml', :package_provider => 'gem' }}
+      it { should contain_package('eyaml').with(
+        'ensure' => 'present',
+        'name' => 'hiera-eyaml',
+        'provider' => 'gem'
+       ) }
+    end
+
+    context "eyaml config directory" do
+      let (:params) {{ :config_dir_ensure => 'directory', :config_dir => '/etc/eyaml', :config_dir_owner => 'root', :config_dir_group => 'root', :config_dir_mode => '0644' }}
+      it {should contain_file('eyaml_config_dir').with(
+        'ensure' => 'directory',
+        'path' => '/etc/eyaml',
+        'owner' => 'root',
+        'group' => 'root',
+        'mode' => '0644'
+      ) }
+    end
+
+    context "eyaml config file creation" do
+      let (:params) {{ :manage_eyaml_config => 'true', :config_ensure => 'file', :config_path => '/etc/yaml/config.yaml', :config_owner => 'root', :config_group => 'root', :config_mode => '0644'  }}
+      it {should contain_file('eyaml_config').with(
+        'ensure' => 'file',
+        'path' => '/etc/yaml/config.yaml',
+        'owner' => 'root',
+        'group' => 'root',
+        'mode' => '0644'
+      ) }
+    end
+
+    context "eyaml keys directory" do
+      let (:params) {{ :keys_dir_ensure => 'directory', :keys_dir => '/etc/yaml/keys', :keys_dir_owner => 'root', :keys_dir_group => 'root', :keys_dir_mode => '0500'  }}
+      it {should contain_file('eyaml_keys_dir').with(
+        'ensure' => 'directory',
+        'path' => '/etc/yaml/keys',
+        'owner' => 'root',
+        'group' => 'root',
+        'mode' => '0500'
+      ) }
+    end
+
+    context "eyaml exec createkeys" do
+      let (:params) {{ :manage_keys => 'true' }}
+      it { should have_exec_resource_count(1) }
+    end
+
+    context "eyaml public key permission" do
+      let (:params) {{ :public_key_path => '/etc/puppet/keys/public_key.pkcs7.pem', :keys_dir_owner => 'root', :keys_dir_group => 'root', :public_key_mode => '0644'  }}
+      it {should contain_file('eyaml_publickey').with(
+        'ensure' => 'file',
+        'path' => '/etc/puppet/keys/public_key.pkcs7.pem',
+        'owner' => 'root',
+        'group' => 'root',
+        'mode' => '0644'
+      ) }
+    end
+
+    context "eyaml private key permission" do
+      let (:params) {{ :private_key_path => '/etc/puppet/keys/private_key.pkcs7.pem', :keys_dir_owner => 'root', :keys_dir_group => 'root', :private_key_mode => '0500'  }}
+      it {should contain_file('eyaml_privatekey').with(
+        'ensure' => 'file',
+        'path' => '/etc/puppet/keys/private_key.pkcs7.pem',
+        'owner' => 'root',
+        'group' => 'root',
+        'mode' => '0500'
+      ) }
+    end
+
+    context 'with defaults for all parameters' do
+      it { should contain_class('eyaml') }
+    end
   end
 end


### PR DESCRIPTION
We are running multiple puppetmasters and we would like to distribute eyaml keys using our own puppet repository for the public key and some other method for the private key. With this PR we can ensure this modules manage file permission on keys and directories.
