### PR TITLE
Modernize (puppet v4 support and rubocop)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ doc/
 
 # Puppet
 coverage/
-spec/fixtures/modules/*
 spec/fixtures/manifests/*
+spec/fixtures/modules/*
 Gemfile.lock
-Modulefile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,45 @@
+---
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  Exclude:
+    - vendor/**/*
+    - pkg/**/*
+    - spec/fixtures/**/*
+
+# Cop's to ignore
+
+# With this enabled it suggests a change that will break the Gemfile
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+# This is a good idea, but does not line up the rest of the lines making it
+# harder to read
+Style/IndentHash:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+# If enabled, this cop makes it harder to understand the logic
+Style/NonNilCheck:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+# Cop's that require ruby >= 1.9
+Style/HashSyntax:
+  Enabled: false
+
+Style/BracesAroundHashParameters:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,39 +2,31 @@
 language: ruby
 
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
 
 env:
   matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-    - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.5.1"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
-    - PUPPET_GEM_VERSION="~> 3.7.0"
-    - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4.0.0" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4.1.0" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4.2.0" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4.3.0" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4.4.0" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4.5.0" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
 
 sudo: false
 
-script: 'bundle exec metadata-json-lint metadata.json && bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake $CHECK'
 
 matrix:
   fast_finish: true
   exclude:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+### v0.3.0
+  Initial publication

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ else
 end
 
 gem 'metadata-json-lint'
-gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppetlabs_spec_helper', '>= 1.1.1'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
-gem 'puppet-lint', :git => 'https://github.com/rodjek/puppet-lint.git'
+gem 'puppet-lint', '>= 1.0', '< 3.0'
 gem 'puppet-lint-absolute_classname-check'
 gem 'puppet-lint-alias-check'
 gem 'puppet-lint-empty_string-check'
@@ -24,7 +24,11 @@ gem 'puppet-lint-undef_in_function-check'
 gem 'puppet-lint-unquoted_string-check'
 gem 'puppet-lint-variable_contains_upcase'
 
-# rspec must be v2 for ruby 1.8.7
-if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
-  gem 'rspec', '~> 2.0'
+if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '2.0'
+  gem 'json', '~> 1.0'
+  gem 'json_pure', '~> 1.0'
+end
+
+if RUBY_VERSION >= '2.0'
+  gem 'rubocop'
 end

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2015 Garrett Honeycutt <code@garretthoneycutt.com>
+Copyright (C) 2015-2016 Garrett Honeycutt <code@garretthoneycutt.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,210 @@ configurable through parameters.
 
 # Compatibility
 ---------------
-This module is built for use with Puppet v3 with Ruby versions 1.8.7, 1.9.3,
-2.0.0 and 2.1.0. It is supported on the following platforms.
+This module is built for use with Puppet v3 (with and without the future
+parser) and v4 and supports Ruby versions v1.9.3, v2.0.0 and v2.1.0, where
+supported by Puppet.
+
+It is supported on the following platforms.
 
 * EL 6
 * EL 7
+* Ubuntu 14.04 LTS
+
+===
+
+# Parameters
+------------
+
+If based on Puppet version, then the path will change. Puppet v3 is `/etc/puppet` and Puppet v4 is `/etc/puppetlabs`.
+
+package_name
+------------
+hiera-eyaml requires the hiera-eyaml gem to be installed.
+
+type: string
+
+- *Default*: hiera-eyaml
+
+package_provider
+----------------
+Package provider to install eyaml.
+
+type: string
+
+- *Default*: Based on Puppet version. Puppet v3 is 'gem' and Puppet v4 is 'puppet_gem'.
+
+package_ensure
+--------------
+Ensure attribute for package.
+
+type: string
+
+- *Default*: 'present'
+
+keys_dir
+--------
+Directory containing public and private keys.
+
+type: string
+
+- *Default*: '${puppet_path}/keys'
+
+keys_dir_owner
+--------------
+Owner of $keys_dir.
+
+type: string
+
+- *Default*: 'root'
+
+keys_dir_group
+--------------
+Group of $keys_dir
+
+type: string
+
+- *Default*: 'root'
+
+keys_dir_mode
+-------------
+Mode of $keys_dir in four digit octal notation.
+
+type: string
+
+- *Default*: '0500'
+
+public_key_path
+---------------
+Absolute path to the public key.
+
+type: string
+
+- *Default*: '${puppet_path}/keys/public_key.pkcs7.pem'
+
+private_key_path
+----------------
+Absolute path to the private key.
+
+type: string
+
+- *Default*: '${puppet_path}/keys/private_key.pkcs7.pem'
+
+public_key_mode
+---------------
+Mode of the public key in four digit octal notation.
+
+type: string
+
+- *Default*: '0644'
+
+private_key_mode
+----------------
+Mode of private key in four digit octal notation.
+
+type: string
+
+- *Default*: '0400'
+
+config_dir
+----------
+Directory for eyaml configuration.
+
+type: string
+
+- *Default*: '/etc/yaml'
+
+config_dir_owner
+----------------
+Owner of $config_dir.
+
+type: string
+
+- *Default*: 'root'
+
+config_dir_group
+----------------
+Group of $config_dir.
+
+type: string
+
+- *Default*: 'root'
+
+config_dir_mode
+---------------
+Mode of $config_dir in four digit octal notation.
+
+type: string
+
+- *Default*: '0755'
+
+config_path
+-----------
+hiera-eyaml config file path.
+
+type: string
+
+- *Default*: '/etc/eyaml/config.yaml'
+
+config_owner
+------------
+Owner of eyaml config file.
+
+type: string
+
+- *Default*: 'root'
+
+config_group
+------------
+Group of eyaml config file.
+
+type: string
+
+- *Default*: 'root'
+
+config_mode
+-----------
+Mode of $config_file in four digit octal notation.
+
+type: string
+
+- *Default*: '0644'
+
+config_options
+--------------
+eyaml custom configurations like (extension, datadir)
+
+type: hash
+
+- *Default*:
+
+```
+{
+  'pkcs7_public_key'  => '${puppet_path}/keys/public_key.pkcs7.pem',
+  'pkcs7_private_key' => '${puppet_path}/keys/private_key.pkcs7.pem',
+},
+```
+
+eyaml_path
+----------
+Path statement to find eyaml command.
+
+type: string
+
+- *Default*: '/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin'
+
+manage_eyaml_config
+-------------------
+Manage eyaml config file.
+
+type: boolean
+
+- *Default*: true
+
+manage_keys_creation
+--------------------
+Manage creation of eyaml keys.
+
+type: boolean
+
+- *Default*: true

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,40 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+require 'metadata-json-lint/rake_task'
+
+if RUBY_VERSION >= '2.0'
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+end
+
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+PuppetLint.configuration.ignore_paths = %w(spec/**/*.pp pkg/**/*.pp)
 
 desc 'Validate manifests, templates, and ruby files'
 task :validate do
   Dir['manifests/**/*.pp'].each do |manifest|
     sh "puppet parser validate --noop #{manifest}"
   end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
-    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  Dir['spec/**/*.rb', 'lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ %r{spec/fixtures}
   end
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end
+
+desc 'Validate that README.md documents all parameters for each class'
+task :validate_readme do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "ext/check_readme.sh #{manifest} README.md"
+  end
+end
+
+desc 'Run metadata_lint, lint, validate, and spec tests.'
+task :test do
+  [:metadata_lint, :lint, :validate_readme, :validate, :spec].each do |test|
+    Rake::Task[test].invoke
   end
 end

--- a/ext/check_readme.sh
+++ b/ext/check_readme.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Copyright 2014 - Garrett Honeycutt <contact@garretthoneycutt.com>
+#
+# Licensed under Apache Software License v2.0
+#
+# usage: ./check_readme.sh manifests/init.pp README.md
+#
+# Simple script to check that parameters in a class are found in the README.
+# This script is opionated on the style of the README. It takes two arguments,
+# the first is the path to the manifest and the second is the path to the
+# README. It will exit 0 on success, 255 on error, or with the number of
+# missing parameters from the README. If there are missing entries, each
+# parameter will be listed on its own line on stdout.
+#
+# assumes that a class or define looks like this
+#
+#  class foo (
+#    $param = 'value',
+#  ) {
+#
+if [ $# -ne 2 ]; then
+  echo "usage: $0 path/to/manifest.pp path/to/README.md"
+  exit 255
+fi
+
+# exit code that starts are 0 (success) and increments by one for every missing
+# parameter
+cnt=0
+
+# the line where the class or define begins
+CLASS_START_LINE=`grep -n -m1 -ie ^class -e ^define $1 | cut -f1 -d:`
+
+# the line where the class or define ends
+CLASS_END_LINE=`grep -n -m1 ^') {' $1 | cut -f1 -d:`
+
+# how many lines to pass to head
+let HEAD_LINES=${CLASS_END_LINE}-1
+
+# how many lines to pass to tail
+let TAIL_LINES=${HEAD_LINES}-${CLASS_START_LINE}
+
+# get the parameter names
+for param in $(head -n $HEAD_LINES $1 | tail -n $TAIL_LINES | awk -F \$ '{print $2}' | awk '{print $1}')
+do
+
+  # quietly look to see if the parameter is found at the beginning of the line
+  # in the README
+  grep -q ^$param $2
+
+  # if not, increment the exit code and print the name of the missing parameter
+  # to stdout
+  if [ $? -ne 0 ]; then
+    echo $param
+    let "cnt += 1"
+  fi
+done
+
+exit $cnt

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,53 +3,104 @@
 # Module to manage eyaml
 #
 class eyaml (
-  $package_name        = 'hiera-eyaml',
-  $package_provider    = 'gem',
-  $package_ensure      = 'present',
-  $keys_dir            = "${::settings::confdir}/keys",
-  $keys_dir_ensure     = 'directory',
-  $keys_dir_owner      = $::settings::user,
-  $keys_dir_group      = $::settings::group,
-  $keys_dir_mode       = '0500',
-  $public_key_path     = '/etc/puppet/keys/public_key.pkcs7.pem',
-  $private_key_path    = '/etc/puppet/keys/private_key.pkcs7.pem',
-  $public_key_mode     = '0644',
-  $private_key_mode    = '0400',
-  $config_dir          = '/etc/eyaml',
-  $config_dir_ensure   = 'directory',
-  $config_dir_owner    = 'root',
-  $config_dir_group    = 'root',
-  $config_dir_mode     = '0755',
-  $config_ensure       = 'file',
-  $config_path         = '/etc/eyaml/config.yaml',
-  $config_owner        = 'root',
-  $config_group        = 'root',
-  $config_mode         = '0644',
-  $config_options      = {
-    'pkcs7_public_key'  => '/etc/puppet/keys/public_key.pkcs7.pem',
-    'pkcs7_private_key' => '/etc/puppet/keys/private_key.pkcs7.pem',
-  },
-  $createkeys_path     = '/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin',
-  $manage_eyaml_config = true,
+  $package_name         = 'hiera-eyaml',
+  $package_provider     = undef,
+  $package_ensure       = 'present',
+  $keys_dir             = undef,
+  $keys_dir_owner       = 'root',
+  $keys_dir_group       = 'root',
+  $keys_dir_mode        = '0500',
+  $public_key_path      = undef,
+  $private_key_path     = undef,
+  $public_key_mode      = '0644',
+  $private_key_mode     = '0400',
+  $config_dir           = '/etc/eyaml',
+  $config_dir_owner     = 'root',
+  $config_dir_group     = 'root',
+  $config_dir_mode      = '0755',
+  $config_path          = '/etc/eyaml/config.yaml',
+  $config_owner         = 'root',
+  $config_group         = 'root',
+  $config_mode          = '0644',
+  $config_options       = undef,
+  $eyaml_path           = '/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin',
+  $manage_eyaml_config  = true,
+  $manage_keys_creation = true,
 ) {
 
+  case $::puppetversion {
+    /^4/: {
+      # puppet v4
+      $default_package_provider = 'puppet_gem'
+      $default_keys_dir         = '/etc/puppetlabs/keys'
+      $default_public_key_path  = '/etc/puppetlabs/keys/public_key.pkcs7.pem'
+      $default_private_key_path = '/etc/puppetlabs/keys/private_key.pkcs7.pem'
+      $default_config_options   = {
+        'pkcs7_public_key'  => '/etc/puppetlabs/keys/public_key.pkcs7.pem',
+        'pkcs7_private_key' => '/etc/puppetlabs/keys/private_key.pkcs7.pem',
+      }
+    }
+    /^3/: {
+      # puppet v3
+      $default_package_provider = 'gem'
+      $default_keys_dir         = '/etc/puppet/keys'
+      $default_public_key_path  = '/etc/puppet/keys/public_key.pkcs7.pem'
+      $default_private_key_path = '/etc/puppet/keys/private_key.pkcs7.pem'
+      $default_config_options   = {
+        'pkcs7_public_key'  => '/etc/puppet/keys/public_key.pkcs7.pem',
+        'pkcs7_private_key' => '/etc/puppet/keys/private_key.pkcs7.pem',
+      }
+    }
+    default: {
+      fail("eyaml support Puppet versions 3 and 4. Detected Puppet version <${::puppetversion}>.")
+    }
+  }
+
+  if $package_provider == undef {
+    $package_provider_real = $default_package_provider
+  } else {
+    $package_provider_real = $package_provider
+  }
+
+  if $keys_dir == undef {
+    $keys_dir_real = $default_keys_dir
+  } else {
+    $keys_dir_real = $keys_dir
+  }
+
+  if $public_key_path == undef {
+    $public_key_path_real = $default_public_key_path
+  } else {
+    $public_key_path_real = $public_key_path
+  }
+
+  if $private_key_path == undef {
+    $private_key_path_real = $default_private_key_path
+  } else {
+    $private_key_path_real = $private_key_path
+  }
+
+  if $config_options == undef {
+    $config_options_real = $default_config_options
+  } else {
+    $config_options_real = $config_options
+  }
+
   validate_string($package_name)
-  validate_string($package_provider)
+  validate_string($package_provider_real)
   validate_string($package_ensure)
-  validate_absolute_path($keys_dir)
-  validate_string($keys_dir_ensure)
+  validate_absolute_path($keys_dir_real)
   validate_string($keys_dir_owner)
   validate_string($keys_dir_group)
   validate_re($keys_dir_mode, '^[0-7]{4}$',
       "eyaml::keys_dir_mode is <${keys_dir_mode}> and must be a valid four digit mode in octal notation.")
-  validate_absolute_path($public_key_path)
-  validate_absolute_path($private_key_path)
+  validate_absolute_path($public_key_path_real)
+  validate_absolute_path($private_key_path_real)
   validate_re($public_key_mode, '^[0-7]{4}$',
       "eyaml::public_key_mode is <${public_key_mode}> and must be a valid four digit mode in octal notation.")
   validate_re($private_key_mode, '^[0-7]{4}$',
       "eyaml::private_key_mode is <${private_key_mode}> and must be a valid four digit mode in octal notation.")
   validate_absolute_path($config_dir)
-  validate_string($config_dir_ensure)
   validate_string($config_dir_owner)
   validate_string($config_dir_group)
   validate_re($config_dir_mode, '^[0-7]{4}$',
@@ -59,8 +110,8 @@ class eyaml (
   validate_string($config_group)
   validate_re($config_mode, '^[0-7]{4}$',
       "eyaml::config_mode is <${config_mode}> and must be a valid four digit mode in octal notation.")
-  validate_hash($config_options)
-  validate_string($createkeys_path)
+  validate_hash($config_options_real)
+  validate_string($eyaml_path)
 
   if is_string($manage_eyaml_config) == true {
     $manage_eyaml_config_bool = str2bool($manage_eyaml_config)
@@ -69,14 +120,21 @@ class eyaml (
   }
   validate_bool($manage_eyaml_config_bool)
 
+  if is_string($manage_keys_creation) == true {
+    $manage_keys_creation_bool = str2bool($manage_keys_creation)
+  } else {
+    $manage_keys_creation_bool = $manage_keys_creation
+  }
+  validate_bool($manage_keys_creation_bool)
+
   package { 'eyaml':
     ensure   => $package_ensure,
     name     => $package_name,
-    provider => $package_provider,
+    provider => $package_provider_real,
   }
 
   file { 'eyaml_config_dir':
-    ensure  => $config_dir_ensure,
+    ensure  => 'directory',
     path    => $config_dir,
     owner   => $config_dir_owner,
     group   => $config_dir_group,
@@ -86,7 +144,7 @@ class eyaml (
 
   if $manage_eyaml_config_bool == true {
     file { 'eyaml_config':
-      ensure  => $config_ensure,
+      ensure  => 'file',
       path    => $config_path,
       content => template('eyaml/config.yaml'),
       owner   => $config_owner,
@@ -97,24 +155,26 @@ class eyaml (
   }
 
   file { 'eyaml_keys_dir':
-    ensure  => $keys_dir_ensure,
-    path    => $keys_dir,
+    ensure  => 'directory',
+    path    => $keys_dir_real,
     owner   => $keys_dir_owner,
     group   => $keys_dir_group,
     mode    => $keys_dir_mode,
     require => Package['eyaml'],
   }
 
-  exec { 'eyaml_createkeys':
-    path    => $createkeys_path,
-    command => "eyaml createkeys --pkcs7-private-key=${private_key_path} --pkcs7-public-key=${public_key_path}",
-    creates => $private_key_path,
-    require => File['eyaml_keys_dir'],
+  if $manage_keys_creation_bool == true {
+    exec { 'eyaml_createkeys':
+      path    => $eyaml_path,
+      command => "eyaml createkeys --pkcs7-private-key=${private_key_path_real} --pkcs7-public-key=${public_key_path_real}",
+      creates => $private_key_path_real,
+      require => File['eyaml_keys_dir'],
+    }
   }
 
   file { 'eyaml_publickey':
     ensure  => file,
-    path    => $public_key_path,
+    path    => $public_key_path_real,
     owner   => $keys_dir_owner,
     group   => $keys_dir_group,
     mode    => $public_key_mode,
@@ -123,7 +183,7 @@ class eyaml (
 
   file { 'eyaml_privatekey':
     ensure  => file,
-    path    => $private_key_path,
+    path    => $private_key_path_real,
     owner   => $keys_dir_owner,
     group   => $keys_dir_group,
     mode    => $private_key_mode,

--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,52 @@
   "project_page": "https://github.com/ghoneycutt/puppet-module-eyaml",
   "issues_url": "https://github.com/ghoneycutt/puppet-module-eyaml/issues",
   "description": "Manage hiera-eyaml",
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">= 3.2.0 < 5.0.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.0.0 < 5.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04"
+      ]
+    }
+  ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"}
   ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,108 @@
 require 'spec_helper'
 describe 'eyaml' do
 
-  context 'with defaults for all parameters' do
-    it { should contain_class('eyaml') }
+  puppetversions = {
+   '3' => {
+      :package_provider => 'gem',
+      :path_prefix      => '/etc/puppet',
+    },
+    '4' => {
+      :package_provider => 'puppet_gem',
+      :path_prefix      => '/etc/puppetlabs',
+    },
+  }
+
+  describe 'with defaults for all parameters' do
+    puppetversions.sort.each do |k,v|
+      context "on puppet v#{k}" do
+        let(:facts) { { :puppetversion => "#{k}.0.0" } }
+
+        it { should contain_class('eyaml') }
+
+        it do
+          should contain_package('eyaml').with(
+            'ensure'   => 'present',
+            'name'     => 'hiera-eyaml',
+            'provider' => v[:package_provider],
+          )
+        end
+
+        it do
+          should contain_file('eyaml_config_dir').with(
+            'ensure'  => 'directory',
+            'path'    => '/etc/eyaml',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0755',
+            'require' => 'Package[eyaml]',
+          )
+        end
+
+        it do
+          should contain_file('eyaml_config').with(
+            'ensure'  => 'file',
+            'path'    => '/etc/eyaml/config.yaml',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0644',
+            'require' => 'File[eyaml_config_dir]',
+          )
+        end
+
+        it do
+          should contain_file('eyaml_config').with_content(
+            %r{^(.*)pkcs7_private_key:(.+)"?#{v[:path_prefix]}/keys/private_key\.pkcs7\.pem"?$}
+          )
+        end
+
+        it do
+          should contain_file('eyaml_config').with_content(
+            %r{^(.*)pkcs7_public_key:(.+)"?#{v[:path_prefix]}/keys/public_key\.pkcs7\.pem"?$}
+          )
+        end
+
+        it do
+          should contain_file('eyaml_keys_dir').with(
+            'ensure'  => 'directory',
+            'path'    => "#{v[:path_prefix]}/keys",
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0500',
+            'require' => 'Package[eyaml]',
+          )
+        end
+
+        it do
+          should contain_exec('eyaml_createkeys').with(
+            'path'    => '/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin',
+            'command' => "eyaml createkeys --pkcs7-private-key=#{v[:path_prefix]}/keys/private_key.pkcs7.pem --pkcs7-public-key=#{v[:path_prefix]}/keys/public_key.pkcs7.pem",
+            'creates' => "#{v[:path_prefix]}/keys/private_key.pkcs7.pem",
+            'require' => 'File[eyaml_keys_dir]',
+          )
+        end
+
+        it do
+          should contain_file('eyaml_publickey').with(
+            'ensure'  => 'file',
+            'path'    => "#{v[:path_prefix]}/keys/public_key.pkcs7.pem",
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0644',
+            'require' => 'Exec[eyaml_createkeys]',
+          )
+        end
+
+        it do
+          should contain_file('eyaml_privatekey').with(
+            'ensure'  => 'file',
+            'path'    => "#{v[:path_prefix]}/keys/private_key.pkcs7.pem",
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0400',
+            'require' => 'Exec[eyaml_createkeys]',
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,13 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |config|
+  config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+  config.before :each do
+    # Ensure that we don't accidentally cache facts and environment between
+    # test cases.  This requires each example group to explicitly load the
+    # facts being exercised with something like
+    # Facter.collection.loader.load(:ipaddress)
+    Facter.clear
+    Facter.clear_messages
+  end
+end

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,6 +1,6 @@
 <% h = {} -%>
-<% @config_options.keys.sort.each do |key| -%>
-<% value = @config_options[key] -%>
+<% @config_options_real.keys.sort.each do |key| -%>
+<% value = @config_options_real[key] -%>
 <% h[key] = value -%>
 <% end -%>
 <%= h.to_yaml %>


### PR DESCRIPTION
Drop support for ruby 1.8.7 and only test against the newest Puppet v3
